### PR TITLE
fix: Pause / Resume thread

### DIFF
--- a/library/src/main/java/com/onlylemi/mapview/library/MapView.java
+++ b/library/src/main/java/com/onlylemi/mapview/library/MapView.java
@@ -37,6 +37,8 @@ public class MapView extends SurfaceView implements SurfaceHolder.Callback, Chor
     private List<MapBaseLayer> layers; // all layers
     private MapLayer mapLayer;
 
+    private boolean hardStopOnVisibilityChanged = false;
+
     //Main rendering thread
     private MapViewRenderer thread; // = new MapViewRenderer();
 
@@ -93,10 +95,11 @@ public class MapView extends SurfaceView implements SurfaceHolder.Callback, Chor
 
     /**
      * Resumes the rendering thread
+     * @param hard - If true we stop the entire update loop, otherwise only drawing stops
      */
-    public void pauseRendering() {
+    public void pauseRendering(boolean hard) {
         if(thread != null) {
-            thread.pause();
+            thread.pause(false);
         }
     }
 
@@ -105,7 +108,7 @@ public class MapView extends SurfaceView implements SurfaceHolder.Callback, Chor
         super.onVisibilityChanged(changedView, state);
 
         if ((state == View.GONE || state == View.INVISIBLE)) {
-            pauseRendering();
+            pauseRendering(hardStopOnVisibilityChanged);
         }else if(state == View.VISIBLE) {
             resumeRendering();
         }
@@ -359,6 +362,10 @@ public class MapView extends SurfaceView implements SurfaceHolder.Callback, Chor
 //        if(thread != null) {
 //            thread.disableFixedFrameRate();
 //        }
+    }
+
+    public void setHardStopOnVisibilityChanged(boolean stopOnVisibilityChanged) {
+        hardStopOnVisibilityChanged = stopOnVisibilityChanged;
     }
 
     //region debugging


### PR DESCRIPTION
* Fixed a problem where pausing the thread was possible but resuming it
again didnt work. Now the user can resume the thread and choose between
a hard pause or a soft pause. If soft paused the updating loop is still
going, aka all logic still works but nothing is drawing. Hard pause
pauses everything except the message looper